### PR TITLE
FOGL-6890 - updated as per standard convention

### DIFF
--- a/make_deb
+++ b/make_deb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-##--------------------------------------------------------------------
-## Copyright (c) 2018 Dianomic Systems
+##--------------------------------------------------------------------------
+## Copyright (c) 2018-2022 Dianomic Systems Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-##--------------------------------------------------------------------
+##--------------------------------------------------------------------------
 ##
 ## Author: Monika Sharma
 ##
 
 set -e
 
-GIT_ROOT=`pwd`    # The script must be executed from the root git directory
+GIT_ROOT=$(pwd)    # The script must be executed from the root git directory
 usage="$(basename "$0") [-h | --help | help] [clean|cleanall]
 This script is used to create the Debian package of fledge-display
 
@@ -72,7 +72,7 @@ then
   exit 1
 fi
 
-version=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[" ,]//g'`
+version=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[" ,]//g')
 BUILD_ROOT="${GIT_ROOT}/packages/build"
 
 # Final package name
@@ -80,7 +80,7 @@ package_name="fledge-display-${version}"
 
 # Print the summary of findings
 echo "The package root directory is         : ${GIT_ROOT}"
-echo "The Fledge display version is        : ${version}"
+echo "The Fledge display version is         : ${version}"
 echo "The package will be built in          : ${BUILD_ROOT}"
 echo "The package name is                   : ${package_name}"
 echo
@@ -99,7 +99,7 @@ if [ ! -L "${BUILD_ROOT}" -a ! -d "${BUILD_ROOT}" ]; then
 fi
 
 cd "${BUILD_ROOT}"
-existing_pkgs=`find . -maxdepth 1 -name "${package_name}.????" | wc -l`
+existing_pkgs=$(find . -maxdepth 1 -name "${package_name}.????" | wc -l)
 existing_pkgs=$((existing_pkgs+1))
 new_stored_pkg=$(printf "${package_name}.%04d" "${existing_pkgs}")
 if [ -d "${package_name}" ]; then
@@ -124,7 +124,7 @@ echo "Done."
 cd "${BUILD_ROOT}"
 
 # Save the old versions
-existing_pkgs=`find . -maxdepth 1 -name "${package_name}.deb.????" | wc -l`
+existing_pkgs=$(find . -maxdepth 1 -name "${package_name}.deb.????" | wc -l)
 existing_pkgs=$((existing_pkgs+1))
 new_stored_pkg=$(printf "${package_name}.deb.%04d" "${existing_pkgs}")
 

--- a/make_deb
+++ b/make_deb
@@ -81,7 +81,7 @@ branch_name=$(git rev-parse --abbrev-ref HEAD)
 # If tagged version is checked out then branch name is HEAD; set it to tag version value
 if [[ $branch_name == "HEAD" ]]; then branch_name=$(git describe --tags); fi
 # Final package name
-if [[ ${branch_name} != "main" ]] && [[ ! ${branch_name} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]] && [[ ! ${branch_name} =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then package_name="fledge-display_${version}-${commit_count}"; version=${git_tag_info:1}; else package_name="fledge-display${version}"; fi
+if [[ ${branch_name} != "main" ]] && [[ ! ${branch_name} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]] && [[ ! ${branch_name} =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then package_name="fledge-display_${version}-${commit_count}"; version=${git_tag_info:1}; else package_name="fledge-display_${version}"; fi
 
 # Print the summary of findings
 echo "The package root directory is         : ${GIT_ROOT}"

--- a/make_deb
+++ b/make_deb
@@ -75,8 +75,13 @@ fi
 version=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[" ,]//g')
 BUILD_ROOT="${GIT_ROOT}/packages/build"
 
+# Get git info
+git_tag_info=$(git describe --tags) && commit_count=$(echo ${git_tag_info} | cut -d- -f2)
+branch_name=$(git rev-parse --abbrev-ref HEAD)
+# If tagged version is checked out then branch name is HEAD; set it to tag version value
+if [[ $branch_name == "HEAD" ]]; then branch_name=$(git describe --tags); fi
 # Final package name
-package_name="fledge-display-${version}"
+if [[ ${branch_name} != "main" ]] && [[ ! ${branch_name} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]] && [[ ! ${branch_name} =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then package_name="fledge-display_${version}-${commit_count}"; version=${git_tag_info:1}; else package_name="fledge-display${version}"; fi
 
 # Print the summary of findings
 echo "The package root directory is         : ${GIT_ROOT}"
@@ -113,6 +118,7 @@ echo -n "Populating the package and updating version file..."
 cd "${package_name}"
 cp -R ${GIT_ROOT}/packages/Debian/* .
 sed -i "s/Version: 0.0.0/Version: ${version}/g" DEBIAN/control
+if [[ ${branch_name} = "main" ]] || [[ ${branch_name} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]] || [[ ${branch_name} =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then echo "Build: ${git_tag_info:1}" >> DEBIAN/control; fi
 echo "Done."
 
 echo "Copying build artifacts for nginx webroot directory..."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fledge-display",
-  "version": "1.0.0",
+  "version": "1.9.2next",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
We might need to remove the existing prerelease tag and recreate it (But optional)

Custom Build Run - http://archives.fledge-iot.org/fixes/display/ubuntu1804/x86_64/

CI scripts will push in FOGL-6770 PR